### PR TITLE
bump rocker version to 4.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rocker/geospatial:4.2.2
+FROM --platform=linux/amd64 rocker/geospatial:4.2.3
 RUN R -q -e 'install.packages(c("rnaturalearth", "rnaturalearthdata", "ebirdst"))' \
     && R -q -e 'remotes::install_github("birdflow-science/BirdFlowModels")' \
     && R -q -e 'remotes::install_github("birdflow-science/BirdFlowR", build_vignettes = TRUE, upgrade = "never")'


### PR DESCRIPTION
This also resolves the new Matrix version dependency in https://github.com/birdflow-science/BirdFlowR/commit/94e03ccee85bf2b0d1af93479e35abae6a4007d6