### PR TITLE
Fixed bug in interval_log_likelihood() 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BirdFlowR
 Title: Predict and Visualize Bird Movement
-Version: 0.0.0.9054
+Version: 0.0.0.9070
 Authors@R: 
     c(person("Ethan", "Plunkett",  email = "plunkett@umass.edu", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4405-2251")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,16 @@
-# BirdflowR 0.0.0.9054
+# BirdFlowR 0.0.0.9070
+2023-04-06
+
+* Switching development version number scheme.  From now on I will increment
+the development version by one with every change in the 
+main branch (merged pull request). Previously the version was the issue number.  
+
+* Fixed #61 (and added test). Now `interval_log_likelihood()` sets `exclude` and 
+`not_active` columns to TRUE if either of the involved observations are entirely
+outside of the extent of the BirdFlow object. Previously locations outside of
+extent resulted in an error.
+
+# BirdFlowR 0.0.0.9054
 2023-03-30
 
 * New interval_loglikelihood() calculates log likelihood for banding and 
@@ -11,7 +23,7 @@ tracking data given a BirdFlow model.
  - `lookup_timestep()` 
 
 
-# BirdflowR 0.0.0.9022 
+# BirdFlowR 0.0.0.9022 
 2023-03-27
 
 * `get_naturalearth()` and related functions now throw a helpful warning if

--- a/R/interval_log_likelihood.R
+++ b/R/interval_log_likelihood.R
@@ -126,7 +126,11 @@ interval_log_likelihood <- function(intervals, observations, bf,
   stopifnot(colnames(coords) == c("x", "y"))
   obs <- obs[, !names(obs) %in% c("x", "y", "i", "timestep")]
   obs <- cbind(obs, coords)
-  obs$i <- xy_to_i(obs$x, obs$y, bf)
+  obs$beyond_extent <-
+    obs$x > xmax(bf) | obs$x < xmin(bf) | obs$y > ymax(bf) | obs$y < ymin(bf)
+  obs$i <- NA
+  sv <- !obs$beyond_extent
+  obs$i[sv] <-  xy_to_i(obs$x[sv], obs$y[sv], bf)
 
   # Convert date to timestep
   obs$ts <- lookup_timestep(obs$date, bf)

--- a/tests/testthat/test-interval_log_likelihood.R
+++ b/tests/testthat/test-interval_log_likelihood.R
@@ -56,23 +56,105 @@ test_that("interval_log_likelihood returns expected values", {
 })
 
 
-test_that("interval_log_likelihood() throws warning if overwriting columns", {
+test_that(
+  "interval_log_likelihood() sets right flags for problematic locations", {
+
+  bf <- BirdFlowModels::rewbla
+  intervals <- BirdFlowModels::rewbla_intervals[1:4, ]
+  observations <- BirdFlowModels::rewbla_observations
+
+  # I'm going to alter locations in observations such that the first four
+  # intervals correspond with (a first observation) that is:
+  # 1. valid location  ->  exclude = FALSE
+  # (2 - 4 all should have exclude = TRUE)
+  # 2. location in an active cell where distr is zero: "dynamic_mask" == TRUE
+  # 3. in extent but not an active cell:  "not active" == TRUE
+  # 4. not in extent:  "not active" == TRUE
+
+  # 1. Valid.  Leave as is.
+
+  # 2. dynamically masked
+  r = 2
+  obs_id <- intervals$from[r]
+  obs_row <- which(observations$id == obs_id)
+  t = lookup_timestep(observations$date[obs_row], bf)
+  d <- get_distr(bf, t)
+  i <- which(d == 0)[1]
+  xy <- i_to_xy(i, bf) |> as.data.frame()
+  pt <- sf::st_as_sf(xy, coords = c("x", "y"), crs = sf::st_crs(crs(bf))) |>
+    sf::st_transform( crs = "EPSG:4326") |>
+    sf::st_coordinates() |>
+    as.data.frame()
+  names(pt) <- c("lon", "lat")
+  observations$lon[obs_row] <- pt$lon
+  observations$lat[obs_row] <- pt$lat
+
+  # 3. Not active (but in extent)
+  r = 3
+  obs_id <- intervals$from[r]
+  obs_row <- which(observations$id == obs_id)
+  mask <- bf$geom$mask
+  cell <- which(!mask)[1]
+  r <- row(mask)[cell]
+  c <- col(mask)[cell]
+  x <- row_to_y(r, bf)
+  y <- col_to_x(c, bf)
+  pt <- data.frame(x = x, y = y) |>
+    sf::st_as_sf(coords = c("x", "y"), crs = sf::st_crs(crs(bf))) |>
+    sf::st_transform( crs = "EPSG:4326") |>
+    sf::st_coordinates() |>
+    as.data.frame()
+  names(pt) <- c("lon", "lat")
+  observations$lon[obs_row] <- pt$lon
+  observations$lat[obs_row] <- pt$lat
+
+  # 4. Not in extent
+  r = 4
+  obs_id <- intervals$from[r]
+  obs_row <- which(observations$id == obs_id)
+  x <- xmax(bf) + 1000
+  y <- ymax(bf) + 1000
+  pt <- data.frame(x = x, y = y) |>
+    sf::st_as_sf(coords = c("x", "y"), crs = sf::st_crs(crs(bf))) |>
+    sf::st_transform( crs = "EPSG:4326") |>
+    sf::st_coordinates() |>
+    as.data.frame()
+  names(pt) <- c("lon", "lat")
+  observations$lon[obs_row] <- pt$lon
+  observations$lat[obs_row] <- pt$lat
+
+  expect_no_error( a <- interval_log_likelihood(intervals, observations, bf) )
+
+  expect_equal(a$exclude, c(FALSE, TRUE, TRUE, TRUE))
+  expect_equal(a$not_active, c(FALSE, FALSE, TRUE, TRUE))
+  expect_equal(a$dynamic_mask, c(FALSE, TRUE, FALSE, FALSE))
+
+
+})
+
+
+test_that( "interval_log_likelihood() throws warning if overwriting columns", {
 
   # Also test that it works fine with verbose = FALSE
   original_verbose <- birdflow_options("verbose")
   on.exit(birdflow_options(verbose = original_verbose))
   birdflow_options(verbose = FALSE)
 
-  bf <- BirdFlowModels::rewbla
-  intervals <- BirdFlowModels::rewbla_intervals[1:10, ]
-  observations <- BirdFlowModels::rewbla_observations
 
-  a <- interval_log_likelihood(intervals, observations, bf)
-  expect_warning(b <- interval_log_likelihood(a, observations, bf),
-                 "These columns will be replaced in the output:")
+    bf <- BirdFlowModels::rewbla
+    intervals <- BirdFlowModels::rewbla_intervals[1:10, ]
+    observations <- BirdFlowModels::rewbla_observations
 
-  expect_equal(a, b)
+    a <- interval_log_likelihood(intervals, observations, bf)
+    expect_warning(b <- interval_log_likelihood(a, observations, bf),
+                   "These columns will be replaced in the output:")
 
-})
+    expect_equal(a, b)
+
+  })
+
+
+
+
 
 


### PR DESCRIPTION
* Previously observations outside of the BirdFlow extent caused `interval_log_likelihood()` to throw an error, now it runs but sets `exclude` and `not_active` columns to TRUE for intervals involving those observations.

* Changed development version number scheme.  Now it increments by 1 whenever the main branch changes.
Fixes #61