### PR TITLE
preprocess_species() updated to force ebirdst columns to their original types.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BirdFlowR
 Title: Predict and Visualize Bird Movement
-Version: 0.0.0.9071
+Version: 0.0.0.9072
 Authors@R: 
     c(person("Ethan", "Plunkett",  email = "plunkett@umass.edu", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4405-2251")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# BirdflowR 0.0.0.9072
+2023-04-11
+
+* Fixed bug introduced when ebirdst 2.2021.1 converted all coljumns of
+ `ebirdst_runs` to character. `preprocess_species()` now defensively forces the 
+  columns that should be (and were) logical to logical, and numeric to numeric. 
+
+
 # BirdFlowR 0.0.0.9071
 2023-04-06
 

--- a/R/preprocess_species.R
+++ b/R/preprocess_species.R
@@ -164,6 +164,7 @@ preprocess_species <- function(species,
   er <- ebirdst::ebirdst_runs
   spmd <- as.list(er[er$species_code == species, , drop = FALSE])
 
+
   if(verbose)
     cat("Species resolved to: '", species, "' (", spmd$common_name, ")\n", sep ="")
 
@@ -180,6 +181,25 @@ preprocess_species <- function(species,
     stop(spmd$common_name, " (", spmd$species_code, ") is a resident ",
          "(non-migratory) species and is therefore a poor candidate for ",
          "BirdFlow modeling.")
+
+  # Restore formatting to ebirdst columns
+  # in ebirdst 2.2021.1 all columns are stored as characters.
+  #  It's fixed by 2.2021.3 but CRAN is still on 2.2021.1
+  logical_variables <- c("resident",
+                         "breeding_range_modeled",
+                         "nonbreeding_range_modeled",
+                         "postbreeding_migration_range_modeled",
+                         "prebreeding_migration_range_modeled")
+
+  numeric_variables <- c("breeding_quality",
+                         "nonbreeding_quality",
+                         "postbreeding_migration_quality",
+                         "prebreeding_migration_quality")
+
+  spmd[logical_variables] <- as.logical(spmd[logical_variables] )
+  spmd[numeric_variables] <- as.numeric(spmd[numeric_variables] )
+
+
 
   model_coverage_variables <- c("breeding_range_modeled",
                                 "nonbreeding_range_modeled",

--- a/tests/testthat/test-preprocess_species.R
+++ b/tests/testthat/test-preprocess_species.R
@@ -43,7 +43,8 @@ test_that("preprocess_species catches error conditions", {
 
   # Error when full range isn't modeled by ebirdst
   runs <- ebirdst::ebirdst_runs
-  i <- which( !runs$resident & !runs$nonbreeding_range_modeled) [1]
+  i <- which(!as.logical(runs$resident) &
+               !as.logical(runs$nonbreeding_range_modeled))[1]
   code <- runs$species_code[i]
   species <- runs$common_name[i]
   err <- paste0(


### PR DESCRIPTION
With ebirdst 2.2021.1 all columns of `ebirdst_runs` are now text; this broke things in BirdFlowR that depended on some columns being logical or numeric (as in previous versions of ebirdst).  `preprocess_species()` was updated to defensively force the variables to the right type.