### PR TITLE
Updated pkgdown configuration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BirdFlowR
 Title: Predict and Visualize Bird Movement
-Version: 0.1.0.9003
+Version: 0.1.0.9004
 Authors@R: 
     c(person("Ethan", "Plunkett",  email = "plunkett@umass.edu", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4405-2251")),
@@ -40,4 +40,5 @@ Imports:
 VignetteBuilder: knitr
 Remotes:
   birdflow-science/BirdFlowModels
-URL: https://birdflow-science.github.io/BirdFlowR/
+URL: https://birdflow-science.github.io/BirdFlowR/, https://github.com/birdflow-science/BirdFlowR
+BugReports: https://github.com/birdflow-science/BirdFlowR/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# BirdflowR 0.1.0.9004
+Made changes to support pkgdown.
+
+* Added links to .yml
+* Added BugReports field to DESCRIPTION file
+* Added a second link to URL field in DESCRIPTION file linking to github repo
+* Switched development mode in .yml to `unreleased`.  `auto` wasn't working with
+  version 0.0.1.x.  When we have our first formal release it should
+  be switched back to `auto`.
+
 # BirdflowR 0.1.0.9003
 
 * `evaluate_performance()` is now exported.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -3,4 +3,11 @@ template:
   bootstrap: 5
 
 development:
-  mode: auto
+  mode: unreleased
+
+home:
+  links:
+  - text: BirdFlow Science
+    href: https://https://birdflow-science.github.io/
+  - text: BirdFlow (python)
+    href:https://github.com/Miguel-Fuentes/birdflow

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -11,4 +11,4 @@ links:
   - text: BirdFlow Science
     href: https:birdflow-science.github.io/
   - text: BirdFlow (python)
-    href:https://github.com/Miguel-Fuentes/birdflow
+    href: https://github.com/Miguel-Fuentes/birdflow


### PR DESCRIPTION
Added links to _pkgdown.yml and DESCRIPTION
Switched development mode in .yml

I'm may not be able to tell if this all works until I try it on the main branch.
Addresses #53 also should make it so that the primary pkgdown site is updated with every merge into main.