### PR TITLE
Defensive changes after release of ebirdst 2022

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BirdFlowR
 Title: Predict and Visualize Bird Movement
-Version: 0.1.0.9037
+Version: 0.1.0.9038
 Authors@R: 
     c(person("Ethan", "Plunkett",  email = "plunkett@umass.edu", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4405-2251")),
@@ -13,7 +13,7 @@ RoxygenNote: 7.2.3
 Suggests: 
     auk,
     BirdFlowModels (>= 0.0.2),
-    ebirdst (>= 2.2021.0),
+    ebirdst (<= 2.2021.3),
     knitr,
     ragg,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
+# BirdFlowR 0.1.0.9038
+2023-11-16
+
+Trying to pass all CI checks while still using ebirdst 2.2021
+
+* Added  version dependency <= 2.2021.3 for **ebirdst** (under imports)
+  to avoid version 3.2022 
+  until **BirdFlowR** is updated for the significant changes in **ebirdst**
+* Removed call to `ebirdst::abundance_palette()` 
+  and replaced it with the resulting values. 
+  As it was **ebirdst** should have been in imports.
+  This also dodges dealing with the function name change in v. 3.2022.0.
+* Dropped code that dealt with older version of `$dates`.
+
 # BirdFlowR 0.1.0.9037
-2023-11-14*
+2023-11-14
 
 * Spelling
   * Checked spelling on package documentation and vignettes. 

--- a/R/lookup_timestep.R
+++ b/R/lookup_timestep.R
@@ -63,16 +63,9 @@ lookup_timestep <- function(x, bf) {
       breaks <- c(dates$start[1], dates$end)
       x <- findInterval(py, vec = breaks, all.inside = TRUE)
 
-    } else {   #  SHOULD be DROPPED when we complete switch to dynamic masking
-      # Support very old models that don't have columns eith "start" and "end";
-      # or "week_start" and "week_end"
-
-      if (nrow(bf$dates) != 52)
-        stop("This is unexpected. bf is both lacking some date columns ",
-             "AND doesn't include all timesteps. To look up timesteps only",
-             " one of those can be true.")
-      x <- ebirdst::date_to_st_week(x)
-
+    } else {
+        stop("This is unexpected. bf$dates is lacking  \"start\" and/or ",
+             "\"end\" columns", sep = "")
     }
   }  # End is date
 

--- a/R/plot_distr.R
+++ b/R/plot_distr.R
@@ -190,9 +190,14 @@ plot_distr <- function(distr,
 
   coast <- get_coastline(bf)
 
-  if (is.null(gradient_colors))
-    gradient_colors <- ebirdst::abundance_palette(10, season = "weekly")
-
+  if (is.null(gradient_colors)) {
+    # Same as ebirdst::abundance_palette(10, season = "weekly")
+    # or  ebirdst::ebirdst_palette(10, season = "weekly") depending
+    # on ebirdst version
+    gradient_colors <-
+      c("#EDDEA5", "#FCCE25", "#FBA238", "#EE7B51", "#DA596A", "#BF3984",
+        "#9D189D", "#7401A8", "#48039F", "#0D0887")
+  }
   p <-
     ggplot2::ggplot(r, ggplot2::aes(x = .data$x,
                                     y = .data$y,

--- a/tests/testthat/test-lookup_timestep.R
+++ b/tests/testthat/test-lookup_timestep.R
@@ -1,30 +1,6 @@
 
-# Make psuedo bf object with dates component
-
-bf <- new_BirdFlow()
-bf$dates <- structure(list(
-  doy = c(4.5, 11.5, 18.5, 25.5, 32.5, 39.5, 46.5,
-          53.5, 60.5, 67.5, 74.5, 81.5, 88.5, 95.5, 102.5, 109.5, 116.5,
-          123.5, 130.5, 137.5, 144.5, 151.5, 158.5, 165.5, 172.5, 179.5,
-          186.5, 193.5, 200.5, 207.5, 214.5, 221.5, 228.5, 235.5, 242.5,
-          249.5, 256.5, 263.5, 270.5, 277.5, 284.5, 291.5, 298.5, 305.5,
-          312.5, 319.5, 326.5, 333.5, 340.5, 347.5, 354.5, 361.5),
-  interval = 1:52,
-  date =
-    structure(c(17900, 17907, 17914, 17921, 17928, 17935,
-                17942, 17949, 17956, 17963, 17970, 17977, 17984, 17991, 17998,
-                18005, 18012, 18019, 18026, 18033, 18040, 18047, 18054, 18061,
-                18068, 18075, 18082, 18089, 18096, 18103, 18110, 18117, 18124,
-                18131, 18138, 18145, 18152, 18159, 18166, 18173, 18180, 18187,
-                18194, 18201, 18208, 18215, 18222, 18229, 18236, 18243, 18250,
-                18257), class = "Date")),
-  class = "data.frame", row.names = c(NA, -52L))
-
-
-
 test_that("lookup_timestep works with character dates", {
-  # Note bf created at top of this test document
-
+  bf <- BirdFlowModels::amewoo
   # Single
   expect_equal(lookup_timestep("2023-01-01", bf), 1)
   # Multiple
@@ -34,8 +10,7 @@ test_that("lookup_timestep works with character dates", {
 
 
 test_that("lookup_timestep works with timesteps", {
-  # Note bf created at top of this test document
-
+  bf <- BirdFlowModels::amewoo
   # Single
   expect_equal(lookup_timestep(1, bf), 1)
   # Multiple


### PR DESCRIPTION
* Dropped call to `ebirdst::abundance_palette()`
* Added dependency on ebirdst <= 2.2021.3  (avoiding 2022) 
* Dropped some backwards compatibility code from `lookup_timesteps()` that relied on **ebirdst** to support pre-dynamic mask models.