### PR TITLE
always override old date column name

### DIFF
--- a/R/snap_to_birdflow.R
+++ b/R/snap_to_birdflow.R
@@ -227,9 +227,6 @@ snap_to_birdflow <- function(d, bf,
 
     d <- as.data.frame(d)
 
-    # restore date column name
-    names(d)[names(d) == "date"] <- date_col
-
     # Make new error for remaining rows
     # We dropped all the errors before aggregation so there are none (yet)
     errors <- make_error_table(nrow(d))

--- a/R/snap_to_birdflow.R
+++ b/R/snap_to_birdflow.R
@@ -264,7 +264,7 @@ snap_to_birdflow <- function(d, bf,
   d$message <- names(errors)[apply(errors, 1, function(x) which(x)[1])]
 
   # Standarize output
-  expected_cols <- c(id_cols, "date", "timestep", "x", "y", "i", "n",
+  expected_cols <- c(id_cols, date_col, "timestep", "x", "y", "i", "n",
                      "error", "message")
 
 

--- a/R/snap_to_birdflow.R
+++ b/R/snap_to_birdflow.R
@@ -264,7 +264,7 @@ snap_to_birdflow <- function(d, bf,
   d$message <- names(errors)[apply(errors, 1, function(x) which(x)[1])]
 
   # Standarize output
-  expected_cols <- c(id_cols, date_col, "timestep", "x", "y", "i", "n",
+  expected_cols <- c(id_cols, "date", "timestep", "x", "y", "i", "n",
                      "error", "message")
 
 


### PR DESCRIPTION
The expected column name here is `date_col`, not hard-coded `"date"`.

See:

https://github.com/birdflow-science/BirdFlowR/blob/4d0be31a8ae0f5c699cd13462d16dba03421c450/R/snap_to_birdflow.R#L230-L231