### PR TITLE
lookup_timestep() results and tests as expected for NA input

### DIFF
--- a/R/lookup_timestep.R
+++ b/R/lookup_timestep.R
@@ -37,13 +37,18 @@ lookup_timestep <- function(x, bf, allow_failure = FALSE) {
   dates <- get_dates(bf) # standardize to current date format
   original_x <- x
 
+  # Deal with length 1 NA input of any class
+  if (length(x) == 1 && is.na(x))
+    x <- NA_real_
+
   # Special case "all" returns all timesteps in order
   if (length(x) == 1 && is.character(x) &&  tolower(x) == "all")
     return(dates$timestep)
 
   # timesteps e.g. "t1" "t2"
   if (is.character(x) && all(grepl("^t[[:digit:]]*$",
-                                   ignore.case = TRUE, x = x))) {
+                                   ignore.case = TRUE,
+                                   x = stats::na.omit(x)))) {
     x <- as.numeric(gsub("t", "", x, ignore.case = TRUE))
   }
 

--- a/tests/testthat/test-lookup_timestep.R
+++ b/tests/testthat/test-lookup_timestep.R
@@ -1,3 +1,34 @@
+test_that("lookup_timestep works with NAs", {
+  bf <- BirdFlowModels::amewoo
+  nice_error <- "^Date lookup failed"
+  # Single (logical) NA, which may be input by user
+  expect_error(lookup_timestep(NA, bf), nice_error)
+  expect_equal(lookup_timestep(NA, bf, allow_failure = TRUE), NA_real_)
+  # Single character NA
+  expect_error(lookup_timestep(NA_character_, bf), nice_error)
+  expect_equal(lookup_timestep(NA_character_, bf, allow_failure = TRUE),
+               NA_real_)
+  # Single numeric NA
+  expect_error(lookup_timestep(NA_real_, bf), nice_error)
+  expect_equal(lookup_timestep(NA_real_, bf, allow_failure = TRUE), NA_real_)
+  # NA in t# style character vector
+  expect_error(lookup_timestep(c('t1', NA_character_), bf), nice_error)
+  expect_equal(lookup_timestep(c('t1', NA_character_), bf,
+                               allow_failure = TRUE),
+               c(1, NA_real_))
+  # NA in numeric vector
+  expect_error(lookup_timestep(c(1, NA_real_), bf), nice_error)
+  expect_equal(lookup_timestep(c(1, NA_real_), bf,
+                               allow_failure = TRUE),
+               c(1, NA_real_))
+  # NA in Date vector
+  expect_error(lookup_timestep(as.Date(c('2023-01-01', NA_character_)), bf),
+               nice_error)
+  expect_equal(lookup_timestep(as.Date(c('2023-01-01', NA_character_)), bf,
+                               allow_failure = TRUE),
+               c(1, NA_real_))
+})
+
 
 test_that("lookup_timestep works with character dates", {
 


### PR DESCRIPTION
`lookup_timestep()` was producing some unexpected results and errors when inputs included NAs.