### PR TITLE
better error message for unsupported argument length to get_metadata()

### DIFF
--- a/R/get_metadata.R
+++ b/R/get_metadata.R
@@ -60,7 +60,7 @@ get_metadata <- function(x, what) {
   nbf <- new_BirdFlow()
   valid_metatdata_names  <- c("all", names(nbf$metadata))
 
-  if (!what %in% c(valid_metatdata_names)) {
+  if (length(what) != 1 || !what %in% c(valid_metatdata_names)) {
     stop("what should be one of ",
          paste(valid_metatdata_names, collapse = ", "))
   }

--- a/tests/testthat/test-get_metadata.R
+++ b/tests/testthat/test-get_metadata.R
@@ -1,0 +1,5 @@
+test_that("get_metadata() errors nicely with wrong input length", {
+  bf <- BirdFlowModels::amewoo
+  expect_error(get_metadata(bf, c('n_transitions', 'n_timesteps')),
+               '^what should be one of')
+})


### PR DESCRIPTION
If user requested more than 1 `what` at a time (unsupported), it broke the if statement, resulting in an unfriendly error message