### PR TITLE
Fix bug in preprocess_species()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BirdFlowR
 Title: Predict and Visualize Bird Movement
-Version: 0.1.0.9056
+Version: 0.1.0.9060
 Authors@R: 
     c(person("Ethan", "Plunkett",  email = "plunkett@umass.edu", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4405-2251")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,18 @@
+
+# BirdFlowR 0.1.0.9060
+2024-05-15 
+
+* Update `preprocess_species()` `crs` argument so that it accepts objects 
+of class `crs` as produced by [sf::st_crs()].
+* Fix bug in `preprocess_species()` that prevented clipping to irregular 
+  polygons.
+
+
 # BirdFlowR 0.1.0.9059
 2024-05-15
 
 * Added `callaghan_abundance` dataset on species populations.
-* Added `get_population()`  function.
+* Added `get_population()`  function.                 
 
 # BirdFlowR 0.1.0.9058
 2024-05-07

--- a/R/preprocess_species.R
+++ b/R/preprocess_species.R
@@ -328,6 +328,11 @@ preprocess_species <- function(species = NULL,
   if (is.null(crs)) {
     crs <- terra::crs(mp$custom_projection)
   } else {
+
+    # Handle objects of class crs (defined in sf)
+    if(inherits(crs, "crs"))
+      crs <- crs$wkt
+
     crs <- terra::crs(crs)
   }
 

--- a/R/process_rasters.R
+++ b/R/process_rasters.R
@@ -165,6 +165,13 @@ process_rasters <- function(res,
   abunds_lci <- terra::project(abunds_lci, mask, method =  project_method)
   bf_msg(" done.\n")
 
+  # Clip data
+  if(!is.null(clip)){
+    abunds <- terra::mask(abunds, clip)
+    abunds_uci <- terra::mask(abunds_uci, clip)
+    abunds_lci <- terra::mask(abunds_lci, clip)
+  }
+
   # aggregate to target resolution
   if (factor != 1) {
     bf_msg("Resampling to target resolution (", res, " km)\n")

--- a/data-raw/callaghan_abundance.R
+++ b/data-raw/callaghan_abundance.R
@@ -27,8 +27,16 @@ names(a) <- n
 
 # Get eBird codes from auk
 t <- auk::ebird_taxonomy
+
+# Based on scientific name
 mv <- match(a$scientific_name, t$scientific_name)
 a$species_code <- t$species_code[mv]
+
+# Based on common name
+unmatched <- is.na(a$species_code)
+
+a$species_code[unmatched] <- t$species_code[match(a$common_name[unmatched], t$common_name)]
+
 
 # Determine which ones are in the current eBird version
 ebird_ver <- ebirdst::ebirdst_version()$version_year

--- a/tests/testthat/helper-get_americas.R
+++ b/tests/testthat/helper-get_americas.R
@@ -1,0 +1,19 @@
+
+# Function to return americas - used for setting up "big run" clipping boundary
+# here so we can reproduce the clipping issue in that run.
+get_americas <- function(clip_to_mainland_us = FALSE, include_hawaii = FALSE){
+  earth <- rnaturalearth::ne_countries(scale = 50)
+  americas <- earth[grep("America", earth$continent), , drop = FALSE]
+  if(clip_to_mainland_us){
+    extent <- c(ymax = 50, ymin = 25, xmin = -130, xmax = -55 )
+    americas <- sf::st_crop(americas, extent)
+    americas <- americas[americas$name == "United States", , drop = FALSE]
+  }
+  # Drop Hawaii
+  if(!include_hawaii){
+    clip <- sf::st_bbox(c(ymax = 25, ymin = 15, xmin = -165, xmax = -150 )) |> sf::st_as_sfc()
+    sf::st_crs(clip) <- "EPSG:4326"
+    americas <- sf::st_difference(americas, clip)
+  }
+  americas
+}


### PR DESCRIPTION
Distributions are now clipped to the clip polygon, not just its extent.