### PR TITLE
Add timeout argument to load_model() and set default to 10 minutes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BirdFlowR
 Title: Predict and Visualize Bird Movement
-Version: 0.1.0.9071
+Version: 0.1.0.9072
 Authors@R: 
     c(person("Ethan", "Plunkett",  email = "plunkett@umass.edu", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4405-2251")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# BirdFlowR 0.1.0.9072
+2025-04-28
+
+Add `timeout` argument to `load_model()` and set default to 10 minutes.
+Previously R's global `timeout` option was used which defaults to 1 minute.
+This should fix the 
+[timeout issue](https://github.com/birdflow-science/BirdFlowR/issues/211)
+that some users experienced with `load_model()`.
 
 # BirdFlowR 0.1.0.9071
 2025-04-16

--- a/R/load_model.R
+++ b/R/load_model.R
@@ -14,6 +14,8 @@
 #' the server); or if working offline.
 #' @param collection_url The url of a collection. Should be the path to
 #' the base directory (not an index.html file).
+#' @param timeout The number of seconds to allow for downloading.  The default
+#' is 600  (ten minutes).
 #' @return The designated BirdFlow model is returned.
 #' @seealso [load_collection_index()]
 #' @examples
@@ -26,8 +28,12 @@
 #'
 #' @export
 load_model <- function(model, update = TRUE,
-                       collection_url = birdflow_options("collection_url")) {
+                       collection_url = birdflow_options("collection_url"),
+                       timeout = 600) {
 
+  original_timeout <- options("timeout")$timeout
+  on.exit(options(timeout = original_timeout))
+  options(timeout = timeout)
 
   collection_url <- gsub("/*$", "/", collection_url) # force trailing slash
 

--- a/man/load_model.Rd
+++ b/man/load_model.Rd
@@ -7,7 +7,8 @@
 load_model(
   model,
   update = TRUE,
-  collection_url = birdflow_options("collection_url")
+  collection_url = birdflow_options("collection_url"),
+  timeout = 600
 )
 }
 \arguments{
@@ -23,6 +24,9 @@ the server); or if working offline.}
 
 \item{collection_url}{The url of a collection. Should be the path to
 the base directory (not an index.html file).}
+
+\item{timeout}{The number of seconds to allow for downloading.  The default
+is 600  (ten minutes).}
 }
 \value{
 The designated BirdFlow model is returned.


### PR DESCRIPTION
Fixes #211 by bumping the default timeout from 1 to 10 minutes and allowing users to increase it further.