### PR TITLE
196 minor things

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,5 @@
 ^man/figures/BirdFlowR_logo.R
 ^\.lintr
 ^data-raw$
+^dev$
+^CLAUDE\.md$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,4 @@
 ^data-raw$
 ^dev$
 ^CLAUDE\.md$
+^\.claude$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -18,3 +18,4 @@
 ^dev$
 ^CLAUDE\.md$
 ^\.claude$
+^\.positai$

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ docs
 
 # Rendered html from rmarkdown template
 inst/markdown_templates/collection_index.html
+.positai
+
+# MacOS clutter
+.DS_store

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BirdFlowR
 Title: Predict and Visualize Bird Movement
-Version: 0.1.0.9079
+Version: 0.1.0.9080
 Authors@R: 
     c(person("Ethan", "Plunkett",  email = "plunkett@umass.edu", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4405-2251")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,16 @@ Round-up of small fixes (closes #196, #115, #197, #219, #222):
   reject non-standard `route_type` values such as `"genoscape"`. The
   validator now warns instead of erroring.
 
+Most of these won't affect users but note:
+* New warnings may appear with `predict()` if some of the weight is
+  outside the dynamic mask.
+* `route()` will now throw an error if the route starts are
+  outside of the dynamic mask.  
+Use `is_distr_valid()` and is `is_location_valid()` to get
+more information on the problematic inputs. 
+  
+
+
 # BirdFlowR 0.1.0.9079
 2026-05-07
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,28 @@
+# BirdFlowR 0.1.0.9080
+2026-05-08
+
+Round-up of small fixes (closes #196, #115, #197, #219, #222):
+
+* Fix typo "weigts" in the BMTR progress message printed by
+  `weight_between()` (and via `calc_bmtr(weighted = TRUE)` /
+  `calc_flux()`).
+* `sparsify()` now honors the documented `p = 0.99` default rather than
+  erroring when `p` is missing. Two adjacent typos in nearby error
+  messages also fixed.
+* `predict()` now warns when the starting distribution has mass on
+  cells the model can't represent at the start timestep, naming the
+  offending column(s); `route()` errors when user-supplied starting
+  coordinates are invalid at the start timestep. Both messages point
+  at `is_distr_valid()` / `is_location_valid()` for diagnosis.
+* `import_birdflow()` no longer leaks rhdf5 file handles across calls —
+  the "An open HDF5 file handle exists ..." nag is gone.
+* Suppress the rhdf5 "chunk size is equal to the dataset dimensions"
+  warning emitted by `export_birdflow()` under R >= 4.5; chunk-size
+  tuning is left as a follow-up if read performance becomes a concern.
+* `Routes()` / `BirdFlowRoutes()` / `BirdFlowIntervals()` no longer
+  reject non-standard `route_type` values such as `"genoscape"`. The
+  validator now warns instead of erroring.
+
 # BirdFlowR 0.1.0.9079
 2026-05-07
 

--- a/R/Routes.R
+++ b/R/Routes.R
@@ -11,9 +11,10 @@
 #'  or `POSIXct`}
 #' \item{`lat`,`lon`}{The latitude and longitude of the location in
 #' WGS84 (EPSG::4326)}
-#' \item{`route_type`}{The type of route - one of
-#' `"tracking"`, `"banding"`, `"motus"`, `"unknown"`, or `"synthetic"`
-#' Types can be mixed in the column.
+#' \item{`route_type`}{The type of route. Standard values are
+#' `"tracking"`, `"banding"`, `"motus"`, `"unknown"`, and `"synthetic"`,
+#' but any character value is accepted; non-standard values produce a
+#' warning. Types can be mixed in the column.
 #' }
 #' }
 #' Other columns are permitted and will be retained in `Routes` object

--- a/R/distribution_performance.R
+++ b/R/distribution_performance.R
@@ -136,7 +136,13 @@ distribution_performance <- function(x, metrics = NULL, ...) {
       # Calculate single step projection correlations
       if (do_step) {
         end_distr <- get_distr(x, to, from_marginals = FALSE)
-        projected <- predict(x, distr = start_distr, start = from, end = to)
+        # eBird-derived start_distr legitimately has mass outside the
+        # marginal-derived support; predict() warns about that, but here
+        # we know and tolerate it.
+        projected <- suppress_specific_warnings(
+          predict(x, distr = start_distr, start = from, end = to),
+          patterns = "mass on cells the model can't represent"
+        )
         end_dm <- get_dynamic_mask(x, to) # end dynamic mask
         single_step_cor[i] <- cor(end_distr[end_dm],
                                   projected[end_dm, ncol(projected)])
@@ -162,8 +168,14 @@ distribution_performance <- function(x, metrics = NULL, ...) {
 
 
     end_distr <- get_distr(x, end, from_marginals = FALSE)
-    projected <- predict(x, distr =  start_distr, start =  start,
-                         end =  end, direction =  "forward")
+    # See note above: eBird start_distr can carry mass outside the
+    # marginal support; the warning is meaningful for direct callers but
+    # noise here.
+    projected <- suppress_specific_warnings(
+      predict(x, distr =  start_distr, start =  start,
+              end =  end, direction =  "forward"),
+      patterns = "mass on cells the model can't represent"
+    )
 
     projected <- projected[, , dim(projected)[3]] # subset to last timestep
     end_dm <- get_dynamic_mask(x, end)

--- a/R/export_birdflow.R
+++ b/R/export_birdflow.R
@@ -78,15 +78,26 @@ export_birdflow <- function(bf, file = NULL,
 
 
   # Write HDF5
+  #
+  # Under R >= 4.5 / current rhdf5, large marginals trigger
+  #   "You created a large dataset with compression and chunking.
+  #    The chunk size is equal to the dataset dimensions ..."
+  # We don't yet have benchmarks to pick better chunk dimensions, so we
+  # suppress this specific warning rather than emit it on every export.
+  # Tracked in #219; revisit if read performance becomes a concern.
   ns <- names(bf)
+  chunk_warning <- "chunk size is equal to the dataset dimensions"
   for (i in seq_along(ns)) {
     n <- ns[i]
-    rhdf5::h5write(bf[[n]],
-                   file = file,
-                   name = n,
-                   native = TRUE,
-                   write.attributes = FALSE,
-                   createnewfile = i == 1)  # TRUE for first object
+    suppress_specific_warnings(
+      rhdf5::h5write(bf[[n]],
+                     file = file,
+                     name = n,
+                     native = TRUE,
+                     write.attributes = FALSE,
+                     createnewfile = i == 1),  # TRUE for first object
+      patterns = chunk_warning
+    )
   }
 
   return(invisible(TRUE))

--- a/R/import_birdflow.R
+++ b/R/import_birdflow.R
@@ -64,9 +64,18 @@
 #' @importFrom Matrix Matrix
 #' @importFrom rhdf5 h5ls
 #' @importFrom rhdf5 h5read
+#' @importFrom rhdf5 h5closeAll
 #' @rdname export_import_birdflow
 #' @export
 import_birdflow <- function(hdf5, ..., version) {
+
+  # rhdf5 keeps an internal table of open file IDs; the h5read() calls
+  # below (and inside import_birdflow_v3()) leak IDs that accumulate
+  # across calls until rhdf5 prints "An open HDF5 file handle exists ...
+  # Run 'h5closeAll()' to close all open HDF5 object handles." Closing
+  # everything on exit silences this and matches the recommendation in
+  # rhdf5's own message. Closes #197.
+  on.exit(h5closeAll(), add = TRUE)
 
   current_version <- new_BirdFlow()$metadata$birdflow_version
 

--- a/R/import_birdflow_v3.R
+++ b/R/import_birdflow_v3.R
@@ -8,10 +8,15 @@
 #' @importFrom Matrix Matrix
 #' @importFrom rhdf5 h5ls
 #' @importFrom rhdf5 h5read
+#' @importFrom rhdf5 h5closeAll
 #' @keywords internal
 import_birdflow_v3 <- function(hdf5) {
 
   stopifnot(file.exists(hdf5))
+
+  # See note in import_birdflow(): close any rhdf5 handles opened by the
+  # h5read() calls below, even on error. Closes #197.
+  on.exit(h5closeAll(), add = TRUE)
 
   #----------------------------------------------------------------------------#
   #   Construct empty object

--- a/R/predict.R
+++ b/R/predict.R
@@ -47,19 +47,22 @@ predict.BirdFlow <- function(object, distr, ...) {
   transitions <- as_transitions(timesteps, object)
   start <- timesteps[1]
 
-  # Reject starting distributions that put probability mass on cells the
-  # model can't represent at `start` (e.g. masked-out cells in a sparsified
-  # model). Without this, predict() silently zeros that mass on the first
-  # multiplication and the result no longer integrates to 1.
+  # Warn if a starting distribution has mass on cells the model can't
+  # represent at `start` (e.g. the eBird distribution often has small mass
+  # on cells outside the marginal-derived support, and sparsification can
+  # zero out additional cells). predict() silently drops that mass on
+  # projection so the warning lets callers diagnose lost probability
+  # without breaking flows like distribution_performance() that
+  # intentionally start from the eBird distribution.
   valid <- is_distr_valid(object, distr, timestep = start)
   if (!all(valid)) {
     bad <- which(!valid)
-    stop("Starting distribution is not valid for the model at timestep ",
-         start,
-         if (multiple_distributions)
-           paste0(" (column", if (length(bad) > 1) "s" else "",
-                  " ", paste(bad, collapse = ", "), ")"),
-         ". See `is_distr_valid()`.")
+    warning("Starting distribution has mass on cells the model can't ",
+            "represent at timestep ", start,
+            if (multiple_distributions)
+              paste0(" (column", if (length(bad) > 1) "s" else "",
+                     " ", paste(bad, collapse = ", "), ")"),
+            "; that mass will be dropped. See `is_distr_valid()`.")
   }
 
   current_dm <- dyn_mask[, start]

--- a/R/predict.R
+++ b/R/predict.R
@@ -47,6 +47,20 @@ predict.BirdFlow <- function(object, distr, ...) {
   transitions <- as_transitions(timesteps, object)
   start <- timesteps[1]
 
+  # Reject starting distributions that put probability mass on cells the
+  # model can't represent at `start` (e.g. masked-out cells in a sparsified
+  # model). Without this, predict() silently zeros that mass on the first
+  # multiplication and the result no longer integrates to 1.
+  valid <- is_distr_valid(object, distr, timestep = start)
+  if (!all(valid)) {
+    bad <- which(!valid)
+    stop("Starting distribution is not valid for the model at timestep ",
+         start,
+         if (multiple_distributions)
+           paste0(" (column", if (length(bad) > 1) "s" else "",
+                  " ", paste(bad, collapse = ", "), ")"),
+         ". See `is_distr_valid()`.")
+  }
 
   current_dm <- dyn_mask[, start]
 

--- a/R/route.R
+++ b/R/route.R
@@ -101,6 +101,20 @@ route <- function(bf,  n = 1, x_coord = NULL, y_coord = NULL,
   # These aren't dynamically masked
   initial_distr <- Matrix::Matrix(0, nrow = n_active(bf), ncol = length(row))
   indices <- rc_to_i(row, col, bf)
+
+  # User-supplied starting coordinates may land on cells that are masked
+  # out (statically or by the dynamic mask at `start`); without this check
+  # such routes silently start with zero probability mass and produce
+  # degenerate output. Sampled starts are valid by construction.
+  if (from_coordinates) {
+    valid <- is_location_valid(bf, i = indices, timestep = start)
+    if (!all(valid)) {
+      bad <- which(!valid)
+      stop("Starting coordinates are not valid for the model at timestep ",
+           start, " (rows ", paste(bad, collapse = ", "),
+           "). See `is_location_valid()`.")
+    }
+  }
   sel <- cbind(indices,  seq_len(length(indices)))
   initial_distr[sel] <- 1
 

--- a/R/sparsify.R
+++ b/R/sparsify.R
@@ -56,9 +56,8 @@
 #' @param x A BirdFlow model.
 #' @param method One of ``"conditional"`, `"marginal"`, or `"model"`.
 #'   See "Methods" section below for details.
-#' @param p Required to control the proportion of the
-#'   probability density retained in the sparsification process. See "Methods"
-#'   below.
+#' @param p Controls the proportion of the probability density retained in
+#'   the sparsification process. Defaults to `0.99`. See "Methods" below.
 #' @param fix If TRUE call [fix_dead_ends()] to eliminate dead ends
 #'   in the sparse model, but only honored if the method produces dead ends.
 #' @param p_protected Only used with `"conditional` method.
@@ -91,7 +90,7 @@ sparsify <- function(x, method, p = 0.99, fix = TRUE, p_protected = .10) {
   if (!all(method %in% supported_methods)) {
     invalid <- setdiff(method, supported_methods)
     stop(paste(invalid, collapse = ", "),
-         ifelse(length(invalid) == 1, " is not a valid mathod.",
+         ifelse(length(invalid) == 1, " is not a valid method.",
                 " are not valid methods."))
   }
 
@@ -104,10 +103,6 @@ sparsify <- function(x, method, p = 0.99, fix = TRUE, p_protected = .10) {
     stop("Currently implemented sparsification only works with marginals")
   if (!has_distr(x))
     stop("Distributions required to evaluate model")
-
-
-  if (missing(p))
-    stop("p is required for for all methods")
 
   if (length(p) != 1 || !is.numeric(p) || ! p > 0 || ! p <= 1)
     stop("p should be a single numeric greater than zero and less than or ",

--- a/R/validate_RouteDataClass.R
+++ b/R/validate_RouteDataClass.R
@@ -373,7 +373,7 @@ get_target_columns_BirdFlowIntervals <- function(type = "input") {
 #'   - `date`: Ensures date formats and non-missing values.
 #'   - `lon` and `lat`: Ensure longitude and latitude values are within
 #'   valid ranges.
-#'   - `route_type`: Ensures only valid route types are present.
+#'   - `route_type`: Warns when non-standard route types are present.
 #' - **Spatial Attributes** (for `BirdFlowRoutes`):
 #'   - `x` and `y`: Ensure numeric spatial coordinates.
 #'   - `i`: Ensures valid spatial indices as integers.
@@ -413,8 +413,8 @@ get_target_columns_BirdFlowIntervals <- function(type = "input") {
 #' not for `Routes`).
 #' @param lon_vector,lat_vector Numeric vectors for longitude and latitude.
 #' Must not contain missing values and must be within valid ranges.
-#' @param route_type_vector A character vector of route types. Must only contain
-#' valid types.
+#' @param route_type_vector A character vector of route types. Any character
+#' values are accepted; non-standard values produce a warning.
 #' @param x_vector,y_vector Numeric vectors for spatial coordinates. Must not
 #' contain missing values.
 #' @param i_vector An integer vector for spatial indices. Must not contain
@@ -491,8 +491,8 @@ validate_Routes_route_type <- function(route_type_vector) {
     invalid_types <-
       unique(route_type_vector)[!unique(route_type_vector) %in%
         valid_route_types]
-    stop(sprintf(
-      "Invalid 'route_type' values found: %s. 'route_type' must be one of: %s",
+    warning(sprintf(
+      "Non-standard 'route_type' values: %s. The standard values are: %s.",
       paste(invalid_types, collapse = ", "),
       paste(valid_route_types, collapse = ", ")
     ))
@@ -505,8 +505,8 @@ validate_BirdFlowRoutes_route_type <- function(route_type_vector) {
   if (!all(unique(route_type_vector) %in% valid_route_types)) {
     invalid_types <- unique(route_type_vector)[!unique(route_type_vector) %in%
       valid_route_types]
-    stop(sprintf(
-      "Invalid 'route_type' values found: %s. 'route_type' must be one of: %s",
+    warning(sprintf(
+      "Non-standard 'route_type' values: %s. The standard values are: %s.",
       paste(invalid_types, collapse = ", "),
       paste(valid_route_types, collapse = ", ")
     ))

--- a/R/weight_between.R
+++ b/R/weight_between.R
@@ -73,7 +73,7 @@ weight_between <- function(bf, weight_fun = NULL, points = NULL, radius = NULL,
                            n_directions = 1, skip_unconnected = TRUE,
                            batch_size = 1e5, ...) {
 
-  bf_msg("Generating between weigts.\n")
+  bf_msg("Generating between weights.\n")
 
   if (!requireNamespace("SparseArray", quietly = TRUE)) {
     stop("The SparseArray package is required to use is_between(). ",

--- a/man/Routes.Rd
+++ b/man/Routes.Rd
@@ -16,9 +16,10 @@ synthetic versions of the same.It must have the following columns:
 or \code{POSIXct}}
 \item{\code{lat},\code{lon}}{The latitude and longitude of the location in
 WGS84 (EPSG::4326)}
-\item{\code{route_type}}{The type of route - one of
-\code{"tracking"}, \code{"banding"}, \code{"motus"}, \code{"unknown"}, or \code{"synthetic"}
-Types can be mixed in the column.
+\item{\code{route_type}}{The type of route. Standard values are
+\code{"tracking"}, \code{"banding"}, \code{"motus"}, \code{"unknown"}, and \code{"synthetic"},
+but any character value is accepted; non-standard values produce a
+warning. Types can be mixed in the column.
 }
 }
 Other columns are permitted and will be retained in \code{Routes} object

--- a/man/attribute_validators.Rd
+++ b/man/attribute_validators.Rd
@@ -70,8 +70,8 @@ not for \code{Routes}).}
 \item{lon_vector, lat_vector}{Numeric vectors for longitude and latitude.
 Must not contain missing values and must be within valid ranges.}
 
-\item{route_type_vector}{A character vector of route types. Must only contain
-valid types.}
+\item{route_type_vector}{A character vector of route types. Any character
+values are accepted; non-standard values produce a warning.}
 
 \item{x_vector, y_vector}{Numeric vectors for spatial coordinates. Must not
 contain missing values.}
@@ -117,7 +117,7 @@ data frames. They check:
 \item \code{date}: Ensures date formats and non-missing values.
 \item \code{lon} and \code{lat}: Ensure longitude and latitude values are within
 valid ranges.
-\item \code{route_type}: Ensures only valid route types are present.
+\item \code{route_type}: Warns when non-standard route types are present.
 }
 \item \strong{Spatial Attributes} (for \code{BirdFlowRoutes}):
 \itemize{

--- a/man/sparsify.Rd
+++ b/man/sparsify.Rd
@@ -12,9 +12,8 @@ sparsify(x, method, p = 0.99, fix = TRUE, p_protected = 0.1)
 \item{method}{One of ``"conditional"\verb{, }"marginal"`, or `"model"`.
 See "Methods" section below for details.}
 
-\item{p}{Required to control the proportion of the
-probability density retained in the sparsification process. See "Methods"
-below.}
+\item{p}{Controls the proportion of the probability density retained in
+the sparsification process. Defaults to \code{0.99}. See "Methods" below.}
 
 \item{fix}{If TRUE call \code{\link[=fix_dead_ends]{fix_dead_ends()}} to eliminate dead ends
 in the sparse model, but only honored if the method produces dead ends.}

--- a/tests/testthat/test-import_birdflow.R
+++ b/tests/testthat/test-import_birdflow.R
@@ -81,3 +81,21 @@ test_that("export_birdflow() and import_birdflow() work with NA in metadata", {
   expect_equal(bf, bf2)
 
 })
+
+test_that("import_birdflow() does not leak rhdf5 handles across calls", {
+  local_quiet()
+  skip_on_cran()
+
+  bf <- BirdFlowModels::amewoo |> truncate_birdflow(start = 1, end = 3)
+  f <- withr::local_tempfile(fileext = ".hdf5")
+  export_birdflow(bf, f)
+
+  # Prime: ensure no stray handles linger from earlier tests / setup.
+  rhdf5::h5closeAll()
+
+  # First import sets the baseline; subsequent imports must not increase
+  # the count of open handles. Pre-fix this triggered the rhdf5 message
+  # "An open HDF5 file handle exists ..." reported in #197.
+  for (i in 1:3) import_birdflow(f)
+  expect_length(rhdf5::h5validObjects(), 0L)
+})

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -46,22 +46,23 @@ test_that("predict() is consistent with marginals and transitions", {
   expect_equal(pred, t_pred)
 })
 
-test_that("predict() rejects starting distributions invalid at the start timestep", {
+test_that("predict() warns on starting distributions with unrepresentable mass", {
   bf <- BirdFlowModels::amewoo
   if (!has_dynamic_mask(bf))
     bf <- add_dynamic_mask(bf)
 
-  # Place all probability mass on a cell that is masked out at timestep 1.
+  # Place all probability mass on a cell that has zero in the
+  # marginal-derived distribution at timestep 1.
   d1 <- get_distr(bf, 1, from_marginals = TRUE)
   bad_i <- which(d1 == 0)[1]
   bad_distr <- numeric(n_active(bf))
   bad_distr[bad_i] <- 1
 
-  expect_error(predict(bf, bad_distr, start = 1, end = 3),
-               "not valid for the model at timestep 1")
+  expect_warning(predict(bf, bad_distr, start = 1, end = 3),
+                 "mass.*can't represent at timestep 1")
 
   # Multi-distribution input names the offending column.
   d_ok <- d1
-  expect_error(predict(bf, cbind(d_ok, bad_distr), start = 1, end = 3),
-               "column 2")
+  expect_warning(predict(bf, cbind(d_ok, bad_distr), start = 1, end = 3),
+                 "column 2")
 })

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -45,3 +45,23 @@ test_that("predict() is consistent with marginals and transitions", {
   expect_no_error(t_pred <-  predict(t_bf, distr, start = 1, end = 3))
   expect_equal(pred, t_pred)
 })
+
+test_that("predict() rejects starting distributions invalid at the start timestep", {
+  bf <- BirdFlowModels::amewoo
+  if (!has_dynamic_mask(bf))
+    bf <- add_dynamic_mask(bf)
+
+  # Place all probability mass on a cell that is masked out at timestep 1.
+  d1 <- get_distr(bf, 1, from_marginals = TRUE)
+  bad_i <- which(d1 == 0)[1]
+  bad_distr <- numeric(n_active(bf))
+  bad_distr[bad_i] <- 1
+
+  expect_error(predict(bf, bad_distr, start = 1, end = 3),
+               "not valid for the model at timestep 1")
+
+  # Multi-distribution input names the offending column.
+  d_ok <- d1
+  expect_error(predict(bf, cbind(d_ok, bad_distr), start = 1, end = 3),
+               "column 2")
+})

--- a/tests/testthat/test-route.R
+++ b/tests/testthat/test-route.R
@@ -100,6 +100,23 @@ test_that("route() works with backwards routes", {
 })
 
 
+test_that("route() rejects starting coordinates that are masked out at start", {
+  bf <- BirdFlowModels::amewoo
+  if (!has_dynamic_mask(bf))
+    bf <- add_dynamic_mask(bf)
+
+  start <- 1
+  d <- get_distr(bf, start, from_marginals = TRUE)
+  bad_i <- which(d == 0)[1]
+  bad_xy <- i_to_xy(bad_i, bf)
+
+  expect_error(
+    route(bf, x_coord = bad_xy[, "x"], y_coord = bad_xy[, "y"],
+          start = start, end = start + 3),
+    "not valid for the model at timestep 1"
+  )
+})
+
 test_that("calc_year_number() works", {
   dates <- seq(from = lubridate::as_date("2004-12-25"),
                to = lubridate::as_date("2005-01-10"),

--- a/tests/testthat/test-sparsify.R
+++ b/tests/testthat/test-sparsify.R
@@ -58,3 +58,31 @@ test_that("sparsification works", {
 
 
 })
+
+test_that("sparsify() uses default p = 0.99 when p is not supplied", {
+  o_verbose <- birdflow_options("verbose")
+  birdflow_options(verbose = FALSE)
+  on.exit(birdflow_options(verbose = o_verbose))
+
+  bf <- truncate_birdflow(BirdFlowModels::amewoo, start = 6, end = 8)
+
+  expect_no_error(default <- sparsify(bf, method = "marginal"))
+  explicit <- sparsify(bf, method = "marginal", p = 0.99)
+
+  # Same nonzero structure for both — confirms the default is 0.99,
+  # not some other value silently substituted by R's missing()-handling.
+  expect_identical(
+    lapply(default$marginals[grep("^M_", names(default$marginals))],
+           function(m) m != 0),
+    lapply(explicit$marginals[grep("^M_", names(explicit$marginals))],
+           function(m) m != 0)
+  )
+})
+
+test_that("sparsify() rejects out-of-range p", {
+  bf <- BirdFlowModels::amewoo
+  expect_error(sparsify(bf, method = "marginal", p = 0),
+               "p should be a single numeric")
+  expect_error(sparsify(bf, method = "marginal", p = 1.5),
+               "p should be a single numeric")
+})

--- a/tests/testthat/test-validate_RouteDataClass.R
+++ b/tests/testthat/test-validate_RouteDataClass.R
@@ -19,3 +19,20 @@ test_that("Validations of Routes, BirdFlowRoutes, and BirdFlowIntervals work", {
     expect_no_error(my_intervals <- as_BirdFlowIntervals(my_bfroutes))
     expect_no_error(validate_BirdFlowIntervals(my_intervals))
 })
+
+test_that("non-standard route_type values warn but do not error", {
+  fake_routes <- make_fake_routes()
+  fake_routes$route_type[1:2] <- "genoscape"
+  species <- list(species_code = "amewoo",
+                  scientific_name = "Scolopax minor",
+                  common_name = "American Woodcock")
+
+  # Construction succeeds with a warning naming the offending value.
+  expect_warning(
+    rts <- Routes(fake_routes, species = species, source = "Maine"),
+    "Non-standard 'route_type'.*genoscape"
+  )
+
+  # And the value round-trips through the object.
+  expect_true("genoscape" %in% rts$data$route_type)
+})


### PR DESCRIPTION

Round-up of small fixes (closes #196, #115, #197, #219, #222):

* Fix typo "weigts" in the BMTR progress message printed by
  `weight_between()` (and via `calc_bmtr(weighted = TRUE)` /
  `calc_flux()`).
* `sparsify()` now honors the documented `p = 0.99` default rather than
  erroring when `p` is missing. Two adjacent typos in nearby error
  messages also fixed.
* `predict()` now warns when the starting distribution has mass on
  cells the model can't represent at the start timestep, naming the
  offending column(s); `route()` errors when user-supplied starting
  coordinates are invalid at the start timestep. Both messages point
  at `is_distr_valid()` / `is_location_valid()` for diagnosis.
* `import_birdflow()` no longer leaks rhdf5 file handles across calls —
  the "An open HDF5 file handle exists ..." nag is gone.
* Suppress the rhdf5 "chunk size is equal to the dataset dimensions"
  warning emitted by `export_birdflow()` under R >= 4.5; chunk-size
  tuning is left as a follow-up if read performance becomes a concern.
* `Routes()` / `BirdFlowRoutes()` / `BirdFlowIntervals()` no longer
  reject non-standard `route_type` values such as `"genoscape"`. The
  validator now warns instead of erroring.

Most of these won't affect users but note:
* New warnings may appear with `predict()` if some of the weight is
  outside the dynamic mask.
* `route()` will now throw an error if the route starts outside of the
  dynamic mask.  
Use `is_distr_valid()` and is `is_location_valid()` to get
more information on the problematic inputs. 
  